### PR TITLE
move to h5 format, minor performance improvement to tag_loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 backend/venv/
 backend/__pycache__/
+backend/*.csv
+backend/*.h5
 *.pyc
 frontend/node_modules/
 frontend/dist/

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ you will probably need somewhere around 16GB of VRAM to run the program?
    ```sh
    pip install -r requirements.txt
    ```
-5. check if `safe.csv` exists in the backend directory. if it is missing fetch it with:
+5. check if `safe.h5` exists in the backend directory. if it is missing fetch it with:
    ```sh
-   curl https://r2.e74000.net/diffusion_frontend_thing/safe.csv
+   curl https://r2.e74000.net/diffusion_frontend_thing/safe.h5
    ```
 6. finally you can run the backend script with:
    ```sh

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ diffusers
 Pillow
 accelerate
 transformers
-pandas
 numpy
 scikit-learn
 faiss-cpu
+h5py

--- a/backend/tag_loader.py
+++ b/backend/tag_loader.py
@@ -1,6 +1,7 @@
 import faiss
 import numpy as np
 from transformers import BertTokenizer, BertModel
+import torch
 
 # Initialize tokenizer and model globally
 model_string = "bert-base-uncased"
@@ -11,7 +12,7 @@ model = BertModel.from_pretrained(model_string)
 print('TagLoader: Loaded model...')
 
 class TagLoader:
-    def __init__(self, file_path='safe.csv'):
+    def __init__(self, file_path='safe.h5'):
         self.tags, self.embeddings = self.load_tags(file_path)
         self.index = self.build_faiss_index(self.embeddings)
         del self.embeddings  # Free up memory by deleting embeddings
@@ -20,16 +21,16 @@ class TagLoader:
         print('TagLoader: Built FAISS index and disposed embeddings.')
     
     def load_tags(self, file_path):
-        import pandas as pd
-        df = pd.read_csv(file_path)
-        tags = df['tag'].values
-        embeddings = df.drop(columns=['tag']).values
+        import h5py
+        with h5py.File(file_path, 'r') as f:
+            tags = np.array(f['tags'], dtype=str)
+            embeddings = np.array(f['embeddings'], dtype=np.float32)
         return tags, embeddings
     
     def build_faiss_index(self, embeddings):
         print("TagLoader: Building FAISS index...")
         index = faiss.IndexFlatL2(embeddings.shape[1])  # Using L2 distance
-        index.add(embeddings.astype(np.float32))
+        index.add(embeddings)
         return index
     
     def find_closest_tag(self, tag, threshold=20.0):
@@ -47,6 +48,7 @@ class TagLoader:
         return self.tags[indices[0]], distances[0]
 
 def embed_tag(tag):
-    inputs = tokenizer(tag, return_tensors='pt')
-    outputs = model(**inputs)
-    return outputs.last_hidden_state.mean(dim=1).detach().numpy()
+    with torch.no_grad():
+        inputs = tokenizer(tag, return_tensors='pt')
+        outputs = model(**inputs)
+        return outputs.last_hidden_state.mean(dim=1).detach().numpy()

--- a/init.bat
+++ b/init.bat
@@ -27,14 +27,14 @@ call venv\Scripts\activate
 echo Installing backend dependencies...
 pip install -r requirements.txt
 
-:: Step 3: Check and fetch safe.csv if not exists
-set SAFE_CSV=backend\safe.csv
+:: Step 3: Check and fetch safe.h5 if not exists
+set SAFE_H5=backend\safe.h5
 
-if not exist "%SAFE_CSV%" (
-    echo Fetching safe.csv...
-    curl -o "%SAFE_CSV%" https://r2.e74000.net/diffusion_frontend_thing/safe.csv
+if not exist "%SAFE_H5%" (
+    echo Fetching safe.h5...
+    curl -o "%SAFE_H5%" https://r2.e74000.net/diffusion_frontend_thing/safe.h5
 ) else (
-    echo safe.csv already exists.
+    echo safe.h5 already exists.
 )
 
 echo Initialization complete.

--- a/init.sh
+++ b/init.sh
@@ -28,14 +28,14 @@ source venv/bin/activate
 echo "Installing backend dependencies..."
 pip install -r requirements.txt
 
-# Step 3: Check and fetch safe.csv if not exists
-SAFE_CSV="safe.csv"
+# Step 3: Check and fetch safe.h5 if not exists
+SAFE_H5="safe.h5"
 
-if [ ! -f "$SAFE_CSV" ]; then
-  echo "Fetching safe.csv..."
-  curl -o $SAFE_CSV https://r2.e74000.net/diffusion_frontend_thing/safe.csv
+if [ ! -f "$SAFE_H5" ]; then
+  echo "Fetching safe.h5..."
+  curl -o $SAFE_H5 https://r2.e74000.net/diffusion_frontend_thing/safe.h5
 else
-  echo "safe.csv already exists."
+  echo "safe.h5 already exists."
 fi
 
 echo "Initialization complete."


### PR DESCRIPTION
changes:
- moved to using h5 format for tag embeddings to improve performance
- no_grad() on embedding function to reduce mem footprint